### PR TITLE
Release 0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,24 @@
 NOTE: cssfinder_backend_numpy follows the [semver](https://semver.org/)
 versioning standard.
 
+### 0.1.1 - 27 April 2023
+
+- Changed set_symmetries function so now takes in a vector of vectors of
+  `PyReadonlyArray2<Complex<f64>>` instead of `PyReadonlyArray2<Complex<f32>>`.
+  The input `f64` arrays are converted to `f32` arrays for processing.
+- Modified src/naive.rs, `apply_symmetries` to add normalization and trace
+  computation to the output matrix.
+- Upgraded cssfinder-backend-rust from version 0.1.0 to 0.1.1.
+- Upgraded getrandom from version 0.2.8 to 0.2.9.
+- Upgraded libc from version 0.2.140 to 0.2.142.
+- Upgraded matrixmultiply from version 0.3.2 to 0.3.3.
+- Upgraded proc-macro2 from version 1.0.54 to 1.0.56.
+- Upgraded pyo3 from version 0.18.2 to 0.18.3.
+- Upgraded pyo3-build-config from version 0.18.2 to 0.18.3.
+- Upgraded pyo3-ffi from version 0.18.2 to 0.18.3.
+- Upgraded pyo3-macros from version 0.18.2 to 0.18.3.
+- Upgraded pyo3-macros-backend from version 0.18.2 to 0.18.3.
+
 ### 0.1.0 - 20 April 2023
 
 - Added `complex64` module with `NaiveRustBackendF32` class as `rust_naive`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,7 +37,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cssfinder-backend-rust"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "ndarray",
  "ndarray-rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cssfinder-backend-rust"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 authors = ["Krzysztof Wisniewski <argmaster.world@gmail.com>"]
 description = "Implementation of CSSFinder backend using Rust."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cssfinder-backend-rust-dev"
-version = "0.1.0"
+version = "0.1.1"
 description = "Development environment for Rust based implementation of CSSFinder backend. Use Maturin to build."
 authors = ["Krzysztof Wisniewski <argmaster.world@gmail.com>"]
 repository = "https://github.com/argmaster/cssfinder_backend_rust"


### PR DESCRIPTION
### 0.1.1 - 27 April 2023

- Changed set_symmetries function so now takes in a vector of vectors of
  `PyReadonlyArray2<Complex<f64>>` instead of `PyReadonlyArray2<Complex<f32>>`.
  The input `f64` arrays are converted to `f32` arrays for processing.
- Modified src/naive.rs, `apply_symmetries` to add normalization and trace
  computation to the output matrix.
- Upgraded cssfinder-backend-rust from version 0.1.0 to 0.1.1.
- Upgraded getrandom from version 0.2.8 to 0.2.9.
- Upgraded libc from version 0.2.140 to 0.2.142.
- Upgraded matrixmultiply from version 0.3.2 to 0.3.3.
- Upgraded proc-macro2 from version 1.0.54 to 1.0.56.
- Upgraded pyo3 from version 0.18.2 to 0.18.3.
- Upgraded pyo3-build-config from version 0.18.2 to 0.18.3.
- Upgraded pyo3-ffi from version 0.18.2 to 0.18.3.
- Upgraded pyo3-macros from version 0.18.2 to 0.18.3.
- Upgraded pyo3-macros-backend from version 0.18.2 to 0.18.3.